### PR TITLE
chore: update Cobrowse.io SDK in sample apps to 3.8.0

### DIFF
--- a/Sample/SampleApp.Android/SampleApp.Android.csproj
+++ b/Sample/SampleApp.Android/SampleApp.Android.csproj
@@ -60,10 +60,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Build.Download">
-      <Version>0.11.0</Version>
+      <Version>0.11.4</Version>
     </PackageReference>
     <PackageReference Include="CobrowseIO.Xamarin">
-      <Version>3.5.0</Version>
+      <Version>3.8.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/Sample/SampleApp.iOS.BroadcastUploadExtension/SampleApp.iOS.BroadcastUploadExtension.csproj
+++ b/Sample/SampleApp.iOS.BroadcastUploadExtension/SampleApp.iOS.BroadcastUploadExtension.csproj
@@ -97,10 +97,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Build.Download">
-      <Version>0.11.0</Version>
+      <Version>0.11.4</Version>
     </PackageReference>
     <PackageReference Include="CobrowseIO.AppExtension.iOS">
-      <Version>3.5.0</Version>
+      <Version>3.8.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.AppExtension.CSharp.targets" />

--- a/Sample/SampleApp.iOS/Info.plist
+++ b/Sample/SampleApp.iOS/Info.plist
@@ -13,7 +13,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MinimumOSVersion</key>
-	<string>9.0</string>
+	<string>11.0</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>

--- a/Sample/SampleApp.iOS/SampleApp.iOS.csproj
+++ b/Sample/SampleApp.iOS/SampleApp.iOS.csproj
@@ -165,13 +165,13 @@
     </ItemGroup>
     <ItemGroup>
       <PackageReference Include="Xamarin.Build.Download">
-        <Version>0.11.0</Version>
+        <Version>0.11.4</Version>
       </PackageReference>
       <PackageReference Include="Xamarin.iOS.SwiftRuntimeSupport">
-        <Version>0.2.0</Version>
+        <Version>0.2.1</Version>
       </PackageReference>
       <PackageReference Include="CobrowseIO.Xamarin">
-        <Version>3.5.0</Version>
+        <Version>3.8.0</Version>
       </PackageReference>
     </ItemGroup>
     <ItemGroup>

--- a/SampleForms/SampleApp.Forms.Android/SampleApp.Forms.Android.csproj
+++ b/SampleForms/SampleApp.Forms.Android/SampleApp.Forms.Android.csproj
@@ -54,10 +54,10 @@
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2515" />
     <PackageReference Include="Xamarin.Build.Download">
-      <Version>0.11.3</Version>
+      <Version>0.11.4</Version>
     </PackageReference>
     <PackageReference Include="CobrowseIO.Xamarin">
-      <Version>3.5.0</Version>
+      <Version>3.8.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/SampleForms/SampleApp.Forms.iOS/Info.plist
+++ b/SampleForms/SampleApp.Forms.iOS/Info.plist
@@ -21,7 +21,7 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>MinimumOSVersion</key>
-	<string>9.0</string>
+	<string>11.0</string>
 	<key>CFBundleDisplayName</key>
 	<string>SampleApp.Forms</string>
 	<key>CFBundleIdentifier</key>

--- a/SampleForms/SampleApp.Forms.iOS/SampleApp.Forms.iOS.csproj
+++ b/SampleForms/SampleApp.Forms.iOS/SampleApp.Forms.iOS.csproj
@@ -132,13 +132,13 @@
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2515" />
     <PackageReference Include="Xamarin.Build.Download">
-      <Version>0.11.3</Version>
+      <Version>0.11.4</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.iOS.SwiftRuntimeSupport">
-      <Version>0.2.0</Version>
+      <Version>0.2.1</Version>
     </PackageReference>
     <PackageReference Include="CobrowseIO.Xamarin">
-      <Version>3.5.0</Version>
+      <Version>3.8.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/SampleForms/SampleApp.Forms/SampleApp.Forms.csproj
+++ b/SampleForms/SampleApp.Forms/SampleApp.Forms.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
+    <BuildWithMSBuildOnMono>true</BuildWithMSBuildOnMono>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -12,6 +13,6 @@
 
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms" Version="5.0.0.2515" />
-    <PackageReference Include="CobrowseIO.Xamarin" Version="3.5.0" />
+    <PackageReference Include="CobrowseIO.Xamarin" Version="3.8.0" />
   </ItemGroup>
 </Project>

--- a/SampleForms/SampleFormsApp.iOS.BroadcastUploadExtension/SampleFormsApp.iOS.BroadcastUploadExtension.csproj
+++ b/SampleForms/SampleFormsApp.iOS.BroadcastUploadExtension/SampleFormsApp.iOS.BroadcastUploadExtension.csproj
@@ -97,10 +97,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.Build.Download">
-      <Version>0.11.3</Version>
+      <Version>0.11.4</Version>
     </PackageReference>
     <PackageReference Include="CobrowseIO.AppExtension.iOS">
-      <Version>3.5.0</Version>
+      <Version>3.8.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.AppExtension.CSharp.targets" />


### PR DESCRIPTION
Using Xamarin.iOS 16.4.0.23 and CobrowseIO.Xamarin 3.8.0 leads to a build error in Debug mode:

```
Compilation failed with code 1, command:
/Applications/Xcode_14.3.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -F /Library/Frameworks/Xamarin.iOS.framework/Versions/16.4.0.23/SDKs/MonoTouch.iphoneos.sdk/Frameworks -framework Mono -framework Foundation -framework CFNetwork -Xlinker -rpath -Xlinker @executable_path/Frameworks -Xlinker -rpath -Xlinker @executable_path/../../Frameworks -Xlinker -rpath -Xlinker @executable_path/ -Xlinker -rpath -Xlinker @executable_path/../.. /Users/user/Projects/cobrowseio/cobrowse-sdk-xamarin/SampleForms/SampleFormsApp.iOS.BroadcastUploadExtension/obj/iPhone/Debug/mtouch-cache/arm64/CobrowseIO.AppExtension.iOS.dll.o /Library/Frameworks/Xamarin.iOS.framework/Versions/16.4.0.23/SDKs/MonoTouch.iphoneos.sdk/lib/libxamarin-debug.dylib /Library/Frameworks/Xamarin.iOS.framework/Versions/16.4.0.23/SDKs/MonoTouch.iphoneos.sdk/lib/libmono-native-unified.dylib -lz -liconv -lz -gdwarf-2 -std=c++14 -I/Library/Frameworks/Xamarin.iOS.framework/Versions/16.4.0.23/SDKs/MonoTouch.iphoneos.sdk/include -isysroot /Applications/Xcode_14.3.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS16.4.sdk -Qunused-arguments -miphoneos-version-min=11.0 -arch arm64 -shared -lz -liconv -install_name @rpath/libCobrowseIO.AppExtension.iOS.dll.dylib -fapplication-extension -o /Users/user/Projects/cobrowseio/cobrowse-sdk-xamarin/SampleForms/SampleFormsApp.iOS.BroadcastUploadExtension/obj/iPhone/Debug/mtouch-cache/arm64/libCobrowseIO.AppExtension.iOS.dll.dylib -D DEBUG -u _OBJC_CLASS_$_CobrowseIOReplayKitExtension
Undefined symbols for architecture arm64:
  "_OBJC_CLASS_$_CobrowseIOReplayKitExtension", referenced from:
     -u command line option
ld: symbol(s) not found for architecture arm64
clang : error : linker command failed with exit code 1 (use -v to see invocation)
MTOUCH : error MT5216: Native linking failed for '/Users/user/Projects/cobrowseio/cobrowse-sdk-xamarin/SampleForms/SampleFormsApp.iOS.BroadcastUploadExtension/obj/iPhone/Debug/mtouch-cache/arm64/libCobrowseIO.AppExtension.iOS.dll.dylib'. Please file a bug report at https://github.com/xamarin/xamarin-macios/issues/new
```

The error is very similar to this bug report which is unlikely to be fixed in Xamarin ever.

- https://github.com/xamarin/xamarin-macios/issues/15258

The error does not occur in Release build.